### PR TITLE
Feature/LP-178 feat: 디렉토리/사이트 정렬 기능 추가 

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/directory/constant/SortType.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/constant/SortType.java
@@ -1,0 +1,7 @@
+package com.linkmoa.source.domain.directory.constant;
+
+public enum SortType {
+	BASIC,
+	NAME,
+	DATE
+}

--- a/src/main/java/com/linkmoa/source/domain/directory/dto/request/DirectoryIdDto.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/dto/request/DirectoryIdDto.java
@@ -2,6 +2,7 @@ package com.linkmoa.source.domain.directory.dto.request;
 
 import java.util.List;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.directory.dto.response.DirectoryDetailResponse;
 import com.linkmoa.source.domain.site.dto.response.SiteDetailResponse;
 import com.linkmoa.source.global.dto.request.BaseRequest;
@@ -13,7 +14,8 @@ public class DirectoryIdDto {
 
 	public record Request(
 		BaseRequest baseRequest,
-		@NotNull Long directoryId
+		@NotNull Long directoryId,
+		SortType sortType
 	) {
 
 	}

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/DirectoryDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/DirectoryDataAccess.java
@@ -3,6 +3,7 @@ package com.linkmoa.source.domain.directory.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.directory.dto.response.DirectoryDetailResponse;
 import com.linkmoa.source.domain.directory.dto.response.DirectorySimpleResponse;
 import com.linkmoa.source.domain.directory.entity.Directory;
@@ -15,7 +16,8 @@ public interface DirectoryDataAccess {
 
 	void delete(Directory directory);
 
-	List<DirectoryDetailResponse> findDirectoryDetails(Long directoryId, List<Long> favoriteDirectoryIds);
+	List<DirectoryDetailResponse> findDirectoryDetails(Long directoryId, List<Long> favoriteDirectoryIds,
+		SortType sortType);
 
 	void decrementDirectoryOrderIndexes(Directory parentDirectory, Integer orderIndex);
 

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/adapter/DirectoryDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/adapter/DirectoryDataAccessImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.directory.dto.response.DirectoryDetailResponse;
 import com.linkmoa.source.domain.directory.dto.response.DirectorySimpleResponse;
 import com.linkmoa.source.domain.directory.entity.Directory;
@@ -37,8 +38,9 @@ public class DirectoryDataAccessImpl implements DirectoryDataAccess {
 	}
 
 	@Override
-	public List<DirectoryDetailResponse> findDirectoryDetails(Long directoryId, List<Long> favoriteDirectoryIds) {
-		return directoryQueryDslRepository.findDirectoryDetails(directoryId, favoriteDirectoryIds);
+	public List<DirectoryDetailResponse> findDirectoryDetails(Long directoryId, List<Long> favoriteDirectoryIds,
+		SortType sortType) {
+		return directoryQueryDslRepository.findDirectoryDetails(directoryId, favoriteDirectoryIds, sortType);
 	}
 
 	@Override

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/rdb/DirectoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/rdb/DirectoryQueryDslRepositoryImpl.java
@@ -10,10 +10,12 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.directory.dto.response.DirectoryDetailResponse;
 import com.linkmoa.source.domain.directory.dto.response.DirectorySimpleResponse;
 import com.linkmoa.source.domain.directory.entity.Directory;
 import com.linkmoa.source.domain.favorite.constant.ItemType;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -25,18 +27,25 @@ import lombok.RequiredArgsConstructor;
 public class DirectoryQueryDslRepositoryImpl {
 	private final JPAQueryFactory jpaQueryFactory;
 
-	public List<DirectoryDetailResponse> findDirectoryDetails(Long directoryId, List<Long> favoriteDirectoryIds) {
+	public List<DirectoryDetailResponse> findDirectoryDetails(Long directoryId, List<Long> favoriteDirectoryIds,
+		SortType sortType) {
+
+		OrderSpecifier<?> orderSpecifier = switch (sortType) {
+			case NAME -> directory.directoryName.asc();
+			case DATE -> directory.createdAt.desc();
+			case BASIC -> directory.orderIndex.asc();
+		};
 
 		return jpaQueryFactory
 			.selectFrom(directory)
 			.where(directory.parentDirectory.id.eq(directoryId))
-			.orderBy(directory.orderIndex.asc())
+			.orderBy(orderSpecifier)
 			.fetch()
 			.stream()
 			.map(d -> DirectoryDetailResponse.builder()
 				.directoryId(d.getId())
 				.directoryName(d.getDirectoryName())
-				.orderIndex(d.getOrderIndex())
+				.orderIndex(sortType == SortType.BASIC ? d.getOrderIndex() : null)
 				.isFavorite(favoriteDirectoryIds.contains(d.getId()))
 				.build())
 			.collect(Collectors.toList());

--- a/src/main/java/com/linkmoa/source/domain/directory/service/DirectoryService.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/service/DirectoryService.java
@@ -213,10 +213,10 @@ public class DirectoryService {
 		List<Long> favoriteSiteIds = favoriteService.findFavoriteSiteIds(favorites);
 
 		List<DirectoryDetailResponse> directoryDetailResponses =
-			directoryDataAccess.findDirectoryDetails(targetDirectory.getId(), favoriteDirectoryIds);
+			directoryDataAccess.findDirectoryDetails(targetDirectory.getId(), favoriteDirectoryIds, request.sortType());
 
 		List<SiteDetailResponse> siteDetailResponses =
-			siteDataAccess.findSitesDetails(targetDirectory.getId(), favoriteSiteIds);
+			siteDataAccess.findSitesDetails(targetDirectory.getId(), favoriteSiteIds, request.sortType());
 
 		return DirectoryIdDto.Response.builder()
 			.targetDirectoryDescription(targetDirectory.getDirectoryDescription())

--- a/src/main/java/com/linkmoa/source/domain/page/service/PageAsyncService.java
+++ b/src/main/java/com/linkmoa/source/domain/page/service/PageAsyncService.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.directory.dto.response.DirectoryDetailResponse;
 import com.linkmoa.source.domain.directory.repository.DirectoryDataAccess;
 import com.linkmoa.source.domain.page.dto.response.PageDetailsResponse;
@@ -26,13 +27,14 @@ public class PageAsyncService {
 	public CompletableFuture<List<DirectoryDetailResponse>> findDirectoryDetailsAsync(Long directoryId,
 		List<Long> favoriteDirectoryIds) {
 		return CompletableFuture.completedFuture(
-			directoryDataAccess.findDirectoryDetails(directoryId, favoriteDirectoryIds));
+			directoryDataAccess.findDirectoryDetails(directoryId, favoriteDirectoryIds, SortType.BASIC));
 	}
 
 	@Async("threadPoolTaskExecutor")
 	public CompletableFuture<List<SiteDetailResponse>> findSitesDetailsAsync(Long directoryId,
 		List<Long> favoriteSiteIds) {
-		return CompletableFuture.completedFuture(siteDataAccess.findSitesDetails(directoryId, favoriteSiteIds));
+		return CompletableFuture.completedFuture(
+			siteDataAccess.findSitesDetails(directoryId, favoriteSiteIds, SortType.BASIC));
 	}
 
 	public CompletableFuture<PageDetailsResponse> combinePageDetails(

--- a/src/main/java/com/linkmoa/source/domain/site/repository/SiteDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/SiteDataAccess.java
@@ -3,6 +3,7 @@ package com.linkmoa.source.domain.site.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.site.dto.response.SiteDetailResponse;
 import com.linkmoa.source.domain.site.dto.response.SiteSimpleResponse;
 import com.linkmoa.source.domain.site.entity.Site;
@@ -14,7 +15,7 @@ public interface SiteDataAccess {
 
 	void delete(Site site);
 
-	List<SiteDetailResponse> findSitesDetails(Long directoryId, List<Long> favoriteSiteIds);
+	List<SiteDetailResponse> findSitesDetails(Long directoryId, List<Long> favoriteSiteIds, SortType sortType);
 
 	List<SiteSimpleResponse> findFavoriteSites(List<Long> favoriteSitesIds);
 }

--- a/src/main/java/com/linkmoa/source/domain/site/repository/adapter/SiteDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/adapter/SiteDataAccessImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.site.dto.response.SiteDetailResponse;
 import com.linkmoa.source.domain.site.dto.response.SiteSimpleResponse;
 import com.linkmoa.source.domain.site.entity.Site;
@@ -37,8 +38,8 @@ public class SiteDataAccessImpl implements SiteDataAccess {
 	}
 
 	@Override
-	public List<SiteDetailResponse> findSitesDetails(Long directoryId, List<Long> favoriteSiteIds) {
-		return siteQueryDslRepository.findSitesDetails(directoryId, favoriteSiteIds);
+	public List<SiteDetailResponse> findSitesDetails(Long directoryId, List<Long> favoriteSiteIds, SortType sortType) {
+		return siteQueryDslRepository.findSitesDetails(directoryId, favoriteSiteIds, sortType);
 	}
 
 	@Override

--- a/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
@@ -9,9 +9,11 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.favorite.constant.ItemType;
 import com.linkmoa.source.domain.site.dto.response.SiteDetailResponse;
 import com.linkmoa.source.domain.site.dto.response.SiteSimpleResponse;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,18 +25,25 @@ import lombok.RequiredArgsConstructor;
 public class SiteQueryDslRepositoryImpl {
 	private final JPAQueryFactory jpaQueryFactory;
 
-	public List<SiteDetailResponse> findSitesDetails(Long directoryId, List<Long> favoriteSiteIds) {
+	public List<SiteDetailResponse> findSitesDetails(Long directoryId, List<Long> favoriteSiteIds, SortType sortType) {
+
+		OrderSpecifier<?> orderSpecifier = switch (sortType) {
+			case NAME -> site.siteName.asc();
+			case DATE -> site.createdAt.desc();
+			case BASIC -> site.orderIndex.asc();
+		};
 
 		return jpaQueryFactory
 			.selectFrom(site)
 			.where(site.directory.id.eq(directoryId))
+			.orderBy(orderSpecifier)
 			.fetch()
 			.stream()
 			.map(s -> SiteDetailResponse.builder()
 				.siteId(s.getId())
 				.siteUrl(s.getSiteUrl())
 				.siteName(s.getSiteName())
-				.orderIndex(s.getOrderIndex())
+				.orderIndex(sortType == SortType.BASIC ? s.getOrderIndex() : null)
 				.isFavorite(favoriteSiteIds.contains(s.getId()))
 				.build())
 			.collect(Collectors.toList());


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[0] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치

feature/LP-178 -> develop

### 변경 사항

디렉토리 및 사이트 정렬 기능(기본순,이름순,날짜순)을 추가했습니다.

### 테스트 결과
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 디렉토리 및 사이트 상세 목록에서 정렬 방식(BASIC, NAME, DATE)을 선택할 수 있는 옵션이 추가되었습니다.

- **버그 수정**
    - 없음

- **기타**
    - 정렬 기준 선택에 따라 목록의 표시 순서가 달라집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->