### PR TITLE
Feature/LP-180 feat : 대시보드 데이터 조회 기능

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/page/controller/PageApiController.java
+++ b/src/main/java/com/linkmoa/source/domain/page/controller/PageApiController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
 import com.linkmoa.source.domain.page.dto.request.PageCreateDto;
+import com.linkmoa.source.domain.page.dto.request.PageDashboardDto;
 import com.linkmoa.source.domain.page.dto.request.PageDeleteDto;
 import com.linkmoa.source.domain.page.dto.response.PageDetailsResponse;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
@@ -110,6 +111,20 @@ public class PageApiController {
 			HttpStatus.OK,
 			"로그인 성공 시, 유저의 개인 페이지 메인 화면 데이터를 조회합니다.",
 			pageService.loadPersonalPageMain(principalDetails)
+		));
+	}
+
+	@GetMapping("/dashboard")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponseSpec<PageDashboardDto.Response>> getPageDashboard(
+		@RequestBody PageDashboardDto.Request request,
+		@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+		return ResponseEntity.ok().body(ApiResponseSpec.success(
+			HttpStatus.OK,
+			"공유 페이지 대시보드 정보를 조회합니다.",
+			pageService.getPageDashboard(request)
+
 		));
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/page/dto/request/PageDashboardDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/request/PageDashboardDto.java
@@ -17,7 +17,6 @@ public class PageDashboardDto {
 	@Builder
 	public record Response(
 		Long pageId,
-		String pageTitle,
 		Boolean isPublic,
 		List<PageDashboardMemberDto> pageMembers
 	) {

--- a/src/main/java/com/linkmoa/source/domain/page/dto/request/PageDashboardDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/request/PageDashboardDto.java
@@ -2,6 +2,7 @@ package com.linkmoa.source.domain.page.dto.request;
 
 import java.util.List;
 
+import com.linkmoa.source.domain.page.contant.PageVisibility;
 import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.global.dto.request.BaseRequest;
 
@@ -17,7 +18,7 @@ public class PageDashboardDto {
 	@Builder
 	public record Response(
 		Long pageId,
-		Boolean isPublic,
+		PageVisibility visibility,
 		List<PageDashboardMemberDto> pageMembers
 	) {
 

--- a/src/main/java/com/linkmoa/source/domain/page/dto/request/PageDashboardDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/request/PageDashboardDto.java
@@ -1,0 +1,26 @@
+package com.linkmoa.source.domain.page.dto.request;
+
+import java.util.List;
+
+import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
+import com.linkmoa.source.global.dto.request.BaseRequest;
+
+import lombok.Builder;
+
+public class PageDashboardDto {
+	public record Request(
+		BaseRequest baseRequest
+	) {
+
+	}
+
+	@Builder
+	public record Response(
+		Long pageId,
+		String pageTitle,
+		Boolean isPublic,
+		List<PageDashboardMemberDto> pageMembers
+	) {
+
+	}
+}

--- a/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
@@ -1,7 +1,5 @@
 package com.linkmoa.source.domain.page.dto.response;
 
-import com.linkmoa.source.domain.memberPageLink.constant.PermissionType;
-
 import lombok.Builder;
 
 @Builder
@@ -9,7 +7,8 @@ public record PageDashboardMemberDto(
 	Long memberId,
 	String email,
 	String nickName,
-	PermissionType permissionType
+	String role,
+	boolean isWaiting
 ) {
 
 }

--- a/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
@@ -1,0 +1,15 @@
+package com.linkmoa.source.domain.page.dto.response;
+
+import com.linkmoa.source.domain.memberPageLink.constant.PermissionType;
+
+import lombok.Builder;
+
+@Builder
+public record PageDashboardMemberDto(
+	Long memberId,
+	String email,
+	String nickName,
+	PermissionType permissionType
+) {
+
+}

--- a/src/main/java/com/linkmoa/source/domain/page/repository/PageDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/PageDataAccess.java
@@ -3,6 +3,7 @@ package com.linkmoa.source.domain.page.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.linkmoa.source.domain.page.contant.PageVisibility;
 import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.linkmoa.source.domain.page.entity.Page;
@@ -29,4 +30,5 @@ public interface PageDataAccess {
 
 	List<PageDashboardMemberDto> findWaitingInvitedMembersByPageId(Long pageId);
 
+	PageVisibility findPageVisibilityByPageId(Long pageId);
 }

--- a/src/main/java/com/linkmoa/source/domain/page/repository/PageDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/PageDataAccess.java
@@ -3,6 +3,7 @@ package com.linkmoa.source.domain.page.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.linkmoa.source.domain.page.entity.Page;
 
@@ -23,5 +24,9 @@ public interface PageDataAccess {
 	Long findRootDirectoryIdByPageId(Long pageId);
 
 	String findPageTitleById(Long pageId);
+
+	List<PageDashboardMemberDto> findDashboardMembersByPageId(Long pageId);
+
+	List<PageDashboardMemberDto> findWaitingInvitedMembersByPageId(Long pageId);
 
 }

--- a/src/main/java/com/linkmoa/source/domain/page/repository/adapter/PageDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/adapter/PageDataAccessImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.page.contant.PageVisibility;
 import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.linkmoa.source.domain.page.entity.Page;
@@ -69,5 +70,10 @@ public class PageDataAccessImpl implements PageDataAccess {
 	@Override
 	public List<PageDashboardMemberDto> findWaitingInvitedMembersByPageId(Long pageId) {
 		return pageQueryDslRepository.findWaitingInvitedMembersByPageId(pageId);
+	}
+
+	@Override
+	public PageVisibility findPageVisibilityByPageId(Long pageId) {
+		return pageQueryDslRepository.findPageVisibilityByPageId(pageId);
 	}
 }

--- a/src/main/java/com/linkmoa/source/domain/page/repository/adapter/PageDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/adapter/PageDataAccessImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.linkmoa.source.domain.page.entity.Page;
 import com.linkmoa.source.domain.page.repository.PageDataAccess;
@@ -58,5 +59,15 @@ public class PageDataAccessImpl implements PageDataAccess {
 	@Override
 	public String findPageTitleById(Long pageId) {
 		return pageJpaRepository.findPageTitleById(pageId);
+	}
+
+	@Override
+	public List<PageDashboardMemberDto> findDashboardMembersByPageId(Long pageId) {
+		return pageQueryDslRepository.findDashboardMembersByPageId(pageId);
+	}
+
+	@Override
+	public List<PageDashboardMemberDto> findWaitingInvitedMembersByPageId(Long pageId) {
+		return pageQueryDslRepository.findWaitingInvitedMembersByPageId(pageId);
 	}
 }

--- a/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.linkmoa.source.domain.page.repository.rdb;
 
+import static com.linkmoa.source.domain.dispatch.entity.QSharePageInvitationRequest.*;
+import static com.linkmoa.source.domain.member.entity.QMember.*;
 import static com.linkmoa.source.domain.memberPageLink.entity.QMemberPageLink.*;
 import static com.linkmoa.source.domain.page.entity.QPage.*;
 
@@ -7,9 +9,12 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
+import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -46,5 +51,39 @@ public class PageQueryDslRepositoryImpl {
 			.from(page)
 			.where(page.id.eq(pageId))
 			.fetchOne();
+	}
+
+	public List<PageDashboardMemberDto> findDashboardMembersByPageId(Long pageId) {
+		return jpaQueryFactory
+			.select(Projections.constructor(
+				PageDashboardMemberDto.class,
+				member.id,
+				member.email,
+				member.nickname,
+				memberPageLink.permissionType.stringValue(),
+				Expressions.constant(false)
+			))
+			.from(memberPageLink)
+			.join(memberPageLink.member, member)
+			.where(memberPageLink.page.id.eq(pageId))
+			.fetch();
+	}
+
+	public List<PageDashboardMemberDto> findWaitingInvitedMembersByPageId(Long pageId) {
+		return jpaQueryFactory
+			.select(Projections.constructor(
+				PageDashboardMemberDto.class,
+				sharePageInvitationRequest.receiver.id,
+				sharePageInvitationRequest.receiver.email,
+				sharePageInvitationRequest.receiver.nickname,
+				Expressions.constant(null),
+				Expressions.constant(true)
+			))
+			.from(sharePageInvitationRequest)
+			.where(
+				sharePageInvitationRequest.page.id.eq(pageId),
+				sharePageInvitationRequest.requestStatus.eq(RequestStatus.WAITING)
+			)
+			.fetch();
 	}
 }

--- a/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
+import com.linkmoa.source.domain.page.contant.PageVisibility;
 import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.querydsl.core.types.Projections;
@@ -86,4 +87,13 @@ public class PageQueryDslRepositoryImpl {
 			)
 			.fetch();
 	}
+
+	public PageVisibility findPageVisibilityByPageId(Long pageId) {
+		return jpaQueryFactory
+			.select(page.visibility)
+			.from(page)
+			.where(page.id.eq(pageId))
+			.fetchOne();
+	}
+
 }

--- a/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
@@ -77,7 +77,7 @@ public class PageQueryDslRepositoryImpl {
 				sharePageInvitationRequest.receiver.id,
 				sharePageInvitationRequest.receiver.email,
 				sharePageInvitationRequest.receiver.nickname,
-				Expressions.constant(null),
+				Expressions.constant("UNKNOWN"),
 				Expressions.constant(true)
 			))
 			.from(sharePageInvitationRequest)

--- a/src/main/java/com/linkmoa/source/domain/page/service/PageService.java
+++ b/src/main/java/com/linkmoa/source/domain/page/service/PageService.java
@@ -2,6 +2,7 @@ package com.linkmoa.source.domain.page.service;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +22,9 @@ import com.linkmoa.source.domain.memberPageLink.entity.MemberPageLink;
 import com.linkmoa.source.domain.memberPageLink.repository.MemberPageLinkDataAccess;
 import com.linkmoa.source.domain.page.contant.PageType;
 import com.linkmoa.source.domain.page.dto.request.PageCreateDto;
+import com.linkmoa.source.domain.page.dto.request.PageDashboardDto;
 import com.linkmoa.source.domain.page.dto.request.PageDeleteDto;
+import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.domain.page.dto.response.PageDetailsResponse;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.linkmoa.source.domain.page.dto.response.SharePageLeaveResponse;
@@ -244,6 +247,23 @@ public class PageService {
 	public Page getPersonalPage(Long memberId) {
 		return memberPageLinkDataAccess.findPersonalPageByMemberId(memberId)
 			.orElseThrow(() -> new PageException(PageErrorCode.PAGE_NOT_FOUND));
+	}
+
+	@ValidationApplied
+	public PageDashboardDto.Response getPageDashboard(PageDashboardDto.Request request) {
+
+		List<PageDashboardMemberDto> allMembers = Stream.concat(
+			pageDataAccess.findDashboardMembersByPageId(
+				request.baseRequest().pageId()).stream(),
+			pageDataAccess.findWaitingInvitedMembersByPageId(
+				request.baseRequest().pageId()).stream()
+		).toList();
+
+		return PageDashboardDto.Response.builder()
+			.pageId(request.baseRequest().pageId())
+			.visibility(pageDataAccess.findPageVisibilityByPageId(request.baseRequest().pageId()))
+			.pageMembers(allMembers)
+			.build();
 	}
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[0] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치
feature/LP-180 -> develop 

### 변경 사항

공유 페이지 대시보드 조회 API 기능을 추가했습니다.
해당 API는 아래 데이터를 반환합니다:

1.pageId: 요청한 페이지의 ID
2.visibility: 페이지 공개 여부 (PUBLIC / RESTRICTED)
3.pageMembers: 해당 페이지에 참여 중인 멤버와 초대 대기 중인 멤버 목록

4.각 멤버에 대해 다음 필드를 포함합니다: 
  1.memberId: 멤버 고유 ID
  2.email: 이메일
  3.nickName: 닉네임
  4.role: 해당 페이지에 대한 권한 (permissionType).
    - 참여 중인 멤버는 실제 permissionType 값 (HOST, EDITOR 등)
    - 초대 대기 중인 멤버는 "UNKNOWN"
  5.isWaiting:
    - false: 현재 페이지에 참여 중인 멤버
    - true: 초대 요청을 받은 대기 중인 멤버

*참고사항
 - 이 API는 공유 페이지에 참여 중인 멤버와 초대 요청이 WAITING 상태인 멤버만 조회합니다.

### 테스트 결과
테스트는  Postman으로 진행했으며, 추후 테스트 코드 추가 예정입니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인증이 필요한 페이지 대시보드 조회 기능이 추가되었습니다. 이제 대시보드에서 페이지의 멤버 정보, 초대 대기 중인 멤버, 페이지 공개 범위 등 다양한 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->