### PR TITLE
Feature/LP-188 feat : 알람 수신 목록 조회 데이터 추가 

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/dispatch/controller/DispatchApiController.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/controller/DispatchApiController.java
@@ -16,7 +16,7 @@ import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
 import com.linkmoa.source.domain.dispatch.dto.request.DirectoryTransmissionDto;
 import com.linkmoa.source.domain.dispatch.dto.request.DispatchProcessingRequest;
 import com.linkmoa.source.domain.dispatch.dto.request.SharePageInvitationRequestDto;
-import com.linkmoa.source.domain.dispatch.dto.response.DispatchDetailResponse;
+import com.linkmoa.source.domain.dispatch.dto.response.DispatchSimpleResponse;
 import com.linkmoa.source.domain.dispatch.dto.response.NotificationsDetailsResponse;
 import com.linkmoa.source.domain.dispatch.service.DispatchMessageResolver;
 import com.linkmoa.source.domain.dispatch.service.DispatchRequestService;
@@ -52,10 +52,10 @@ public class DispatchApiController {
 
 	@PatchMapping("/directory-transmissions/status")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponseSpec<DispatchDetailResponse>> processDirectoryTransmission(
+	public ResponseEntity<ApiResponseSpec<DispatchSimpleResponse>> processDirectoryTransmission(
 		@RequestBody @Validated DispatchProcessingRequest dispatchProcessingRequest,
 		@AuthenticationPrincipal PrincipalDetails principalDetails) {
-		DispatchDetailResponse response = directoryTransmissionRequestProcessor.processRequest(
+		DispatchSimpleResponse response = directoryTransmissionRequestProcessor.processRequest(
 			dispatchProcessingRequest, principalDetails);
 		return ResponseEntity.ok().body(ApiResponseSpec.success(
 			HttpStatus.OK,
@@ -79,11 +79,11 @@ public class DispatchApiController {
 
 	@PatchMapping("/share-page-invitations/status")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponseSpec<DispatchDetailResponse>> processSharePageInvitation(
+	public ResponseEntity<ApiResponseSpec<DispatchSimpleResponse>> processSharePageInvitation(
 		@RequestBody @Validated DispatchProcessingRequest dispatchProcessingRequest,
 		@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-		DispatchDetailResponse response = sharePageInvitationRequestProcessor.processRequest(
+		DispatchSimpleResponse response = sharePageInvitationRequestProcessor.processRequest(
 			dispatchProcessingRequest, principalDetails);
 
 		return ResponseEntity.ok().body(ApiResponseSpec.success(

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DirectoryTransmissionRequestRawResult.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DirectoryTransmissionRequestRawResult.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
 import com.linkmoa.source.domain.notification.constant.NotificationType;
 
-public record DispatchRawResult(
+public record DirectoryTransmissionRequestRawResult(
 	Long id,
 	String email,
 	String nickname,
@@ -14,6 +14,5 @@ public record DispatchRawResult(
 	String message,
 	RequestStatus requestStatus,
 	NotificationType notificationType
-
 ) {
 }

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DirectoryTransmissionRequestRawResult.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DirectoryTransmissionRequestRawResult.java
@@ -11,7 +11,6 @@ public record DirectoryTransmissionRequestRawResult(
 	String nickname,
 	String colorCode,
 	LocalDateTime sentAt,
-	String message,
 	RequestStatus requestStatus,
 	NotificationType notificationType
 ) {

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DirectoryTransmissionRequestRawResult.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DirectoryTransmissionRequestRawResult.java
@@ -12,6 +12,7 @@ public record DirectoryTransmissionRequestRawResult(
 	String colorCode,
 	LocalDateTime sentAt,
 	RequestStatus requestStatus,
-	NotificationType notificationType
+	NotificationType notificationType,
+	String directoryName
 ) {
 }

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchDetailResponse.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchDetailResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 @Builder
 public record DispatchDetailResponse(
 	Long id,
-	String senderEmail,
+	NotificationSenderInfo senderInfo,
 	RequestStatus requestStatus,
 	NotificationType notificationType
 ) {

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchRawResult.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchRawResult.java
@@ -1,2 +1,19 @@
-package com.linkmoa.source.domain.dispatch.dto.response;public record DispatchRawResult() {
+package com.linkmoa.source.domain.dispatch.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
+import com.linkmoa.source.domain.notification.constant.NotificationType;
+
+public record DispatchRawResult(
+	Long id,
+	String email,
+	String nickname,
+	String colorCode,
+	LocalDateTime sentAt,
+	String message,
+	RequestStatus requestStatus,
+	NotificationType notificationType
+
+) {
 }

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchRawResult.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchRawResult.java
@@ -1,0 +1,2 @@
+package com.linkmoa.source.domain.dispatch.dto.response;public record DispatchRawResult() {
+}

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchSimpleResponse.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchSimpleResponse.java
@@ -1,0 +1,2 @@
+package com.linkmoa.source.domain.dispatch.dto.response;public record DispatchSimpleResponse() {
+}

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchSimpleResponse.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/DispatchSimpleResponse.java
@@ -1,2 +1,17 @@
-package com.linkmoa.source.domain.dispatch.dto.response;public record DispatchSimpleResponse() {
+package com.linkmoa.source.domain.dispatch.dto.response;
+
+import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
+import com.linkmoa.source.domain.notification.constant.NotificationType;
+
+public record DispatchSimpleResponse(
+	Long id,
+	RequestStatus requestStatus,
+	String senderEmail,
+	NotificationType notificationType
+) {
+	public static DispatchSimpleResponse of(Long id, RequestStatus status, String senderEmail, NotificationType type) {
+		return new DispatchSimpleResponse(id, status, senderEmail, type);
+	}
 }
+
+

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/NotificationSenderInfo.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/NotificationSenderInfo.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 @Builder
 public record NotificationSenderInfo(
 	String email,
+	String nickname,
 	String colorCode,
 	LocalDateTime sentAt,
 	String message

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/NotificationSenderInfo.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/NotificationSenderInfo.java
@@ -1,0 +1,14 @@
+package com.linkmoa.source.domain.dispatch.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record NotificationSenderInfo(
+	String email,
+	String colorCode,
+	LocalDateTime sentAt,
+	String message
+) {
+}

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/NotificationSenderInfo.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/NotificationSenderInfo.java
@@ -9,7 +9,6 @@ public record NotificationSenderInfo(
 	String email,
 	String nickname,
 	String colorCode,
-	LocalDateTime sentAt,
-	String message
+	LocalDateTime sentAt
 ) {
 }

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/SharePageInvitationRequestRawResult.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/SharePageInvitationRequestRawResult.java
@@ -1,16 +1,19 @@
 package com.linkmoa.source.domain.dispatch.dto.response;
 
+import java.time.LocalDateTime;
+
 import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
 import com.linkmoa.source.domain.notification.constant.NotificationType;
 
-import lombok.Builder;
-
-@Builder
-public record DispatchDetailResponse(
+public record SharePageInvitationRequestRawResult(
 	Long id,
-	NotificationSenderInfo senderInfo,
+	String email,
+	String nickname,
+	String colorCode,
+	LocalDateTime sentAt,
+	String message,
 	RequestStatus requestStatus,
 	NotificationType notificationType,
-	String message
+	String pageTitle
 ) {
 }

--- a/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/SharePageInvitationRequestRawResult.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/dto/response/SharePageInvitationRequestRawResult.java
@@ -11,7 +11,6 @@ public record SharePageInvitationRequestRawResult(
 	String nickname,
 	String colorCode,
 	LocalDateTime sentAt,
-	String message,
 	RequestStatus requestStatus,
 	NotificationType notificationType,
 	String pageTitle

--- a/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/DirectoryTransmissionRequestQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/DirectoryTransmissionRequestQueryDslRepositoryImpl.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.linkmoa.source.domain.dispatch.dto.response.DirectoryTransmissionRequestRawResult;
 import com.linkmoa.source.domain.dispatch.dto.response.DispatchDetailResponse;
-import com.linkmoa.source.domain.dispatch.dto.response.DispatchRawResult;
 import com.linkmoa.source.domain.dispatch.dto.response.NotificationSenderInfo;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,9 +23,9 @@ public class DirectoryTransmissionRequestQueryDslRepositoryImpl {
 
 	public List<DispatchDetailResponse> findAllDirectoryTransmissionRequestByReceiverEmail(String receiverEmail) {
 
-		List<DispatchRawResult> rawResults = jpaQueryFactory.select(
+		List<DirectoryTransmissionRequestRawResult> rawResults = jpaQueryFactory.select(
 				Projections.constructor(
-					DispatchRawResult.class,
+					DirectoryTransmissionRequestRawResult.class,
 					directoryTransmissionRequest.id,
 					directoryTransmissionRequest.sender.email,
 					directoryTransmissionRequest.sender.nickname,
@@ -45,11 +45,11 @@ public class DirectoryTransmissionRequestQueryDslRepositoryImpl {
 					raw.email(),
 					raw.nickname(),
 					raw.colorCode(),
-					raw.sentAt(),
-					String.format("%s(%s)님이 회원님에게 디렉토리를 전송했습니다.", raw.nickname(), raw.email())
+					raw.sentAt()
 				),
 				raw.requestStatus(),
-				raw.notificationType()
+				raw.notificationType(),
+				String.format("%s(%s)님이 회원님에게 디렉토리를 전송했습니다.", raw.nickname(), raw.email())
 			)).toList();
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/DirectoryTransmissionRequestQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/DirectoryTransmissionRequestQueryDslRepositoryImpl.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.linkmoa.source.domain.dispatch.dto.response.DispatchDetailResponse;
+import com.linkmoa.source.domain.dispatch.dto.response.DispatchRawResult;
+import com.linkmoa.source.domain.dispatch.dto.response.NotificationSenderInfo;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,11 +23,14 @@ public class DirectoryTransmissionRequestQueryDslRepositoryImpl {
 
 	public List<DispatchDetailResponse> findAllDirectoryTransmissionRequestByReceiverEmail(String receiverEmail) {
 
-		List<DispatchDetailResponse> result = jpaQueryFactory.select(
+		List<DispatchRawResult> rawResults = jpaQueryFactory.select(
 				Projections.constructor(
-					DispatchDetailResponse.class,
+					DispatchRawResult.class,
 					directoryTransmissionRequest.id,
 					directoryTransmissionRequest.sender.email,
+					directoryTransmissionRequest.sender.nickname,
+					directoryTransmissionRequest.sender.colorCode,
+					directoryTransmissionRequest.createdAt,
 					directoryTransmissionRequest.requestStatus,
 					directoryTransmissionRequest.notificationType
 				))
@@ -33,7 +38,19 @@ public class DirectoryTransmissionRequestQueryDslRepositoryImpl {
 			.where(receiverEmailEq(receiverEmail))
 			.fetch();
 
-		return result;
+		return rawResults.stream()
+			.map(raw -> new DispatchDetailResponse(
+				raw.id(),
+				new NotificationSenderInfo(
+					raw.email(),
+					raw.nickname(),
+					raw.colorCode(),
+					raw.sentAt(),
+					String.format("%s(%s)님이 회원님에게 디렉토리를 전송했습니다.", raw.nickname(), raw.email())
+				),
+				raw.requestStatus(),
+				raw.notificationType()
+			)).toList();
 	}
 
 	private BooleanExpression receiverEmailEq(String receiverEmail) {

--- a/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/DirectoryTransmissionRequestQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/DirectoryTransmissionRequestQueryDslRepositoryImpl.java
@@ -32,7 +32,8 @@ public class DirectoryTransmissionRequestQueryDslRepositoryImpl {
 					directoryTransmissionRequest.sender.colorCode,
 					directoryTransmissionRequest.createdAt,
 					directoryTransmissionRequest.requestStatus,
-					directoryTransmissionRequest.notificationType
+					directoryTransmissionRequest.notificationType,
+					directoryTransmissionRequest.directory.directoryName
 				))
 			.from(directoryTransmissionRequest)
 			.where(receiverEmailEq(receiverEmail))
@@ -49,7 +50,7 @@ public class DirectoryTransmissionRequestQueryDslRepositoryImpl {
 				),
 				raw.requestStatus(),
 				raw.notificationType(),
-				String.format("%s(%s)님이 회원님에게 디렉토리를 전송했습니다.", raw.nickname(), raw.email())
+				String.format("%s(%s)님이 회원님에게 %s디렉토리를 전송했습니다.", raw.nickname(), raw.email(), raw.directoryName())
 			)).toList();
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/SharePageInvitationRequestQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/repository/rdb/SharePageInvitationRequestQueryDslRepositoryImpl.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.linkmoa.source.domain.dispatch.dto.response.DispatchDetailResponse;
+import com.linkmoa.source.domain.dispatch.dto.response.NotificationSenderInfo;
+import com.linkmoa.source.domain.dispatch.dto.response.SharePageInvitationRequestRawResult;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,19 +23,36 @@ public class SharePageInvitationRequestQueryDslRepositoryImpl {
 
 	public List<DispatchDetailResponse> findAllSharePageInvitationsByReceiverEmail(String receiverEmail) {
 
-		List<DispatchDetailResponse> result = jpaQueryFactory.select
-				(Projections.constructor(
-					DispatchDetailResponse.class,
+		List<SharePageInvitationRequestRawResult> rawResults = jpaQueryFactory.select(
+				Projections.constructor(
+					SharePageInvitationRequestRawResult.class,
 					sharePageInvitationRequest.id,
 					sharePageInvitationRequest.sender.email,
+					sharePageInvitationRequest.sender.nickname,
+					sharePageInvitationRequest.sender.colorCode,
+					sharePageInvitationRequest.createdAt,
 					sharePageInvitationRequest.requestStatus,
-					sharePageInvitationRequest.notificationType
+					sharePageInvitationRequest.notificationType,
+					sharePageInvitationRequest.page.pageTitle
 				))
 			.from(sharePageInvitationRequest)
 			.where(receiverEmailEq(receiverEmail))
 			.fetch();
 
-		return result;
+		return rawResults.stream()
+			.map(raw -> new DispatchDetailResponse(
+				raw.id(),
+				new NotificationSenderInfo(
+					raw.email(),
+					raw.nickname(),
+					raw.colorCode(),
+					raw.sentAt()
+				),
+				raw.requestStatus(),
+				raw.notificationType(),
+				String.format("%s(%s)님이 회원님에게 %s 페이지에 초대했습니다.", raw.nickname(), raw.email(), raw.pageTitle())
+
+			)).toList();
 	}
 
 	private BooleanExpression receiverEmailEq(String receiverEmail) {

--- a/src/main/java/com/linkmoa/source/domain/dispatch/service/processor/DirectoryTransmissionRequestProcessor.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/service/processor/DirectoryTransmissionRequestProcessor.java
@@ -8,7 +8,7 @@ import com.linkmoa.source.domain.directory.entity.Directory;
 import com.linkmoa.source.domain.directory.service.DirectoryService;
 import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
 import com.linkmoa.source.domain.dispatch.dto.request.DispatchProcessingRequest;
-import com.linkmoa.source.domain.dispatch.dto.response.DispatchDetailResponse;
+import com.linkmoa.source.domain.dispatch.dto.response.DispatchSimpleResponse;
 import com.linkmoa.source.domain.dispatch.entity.DirectoryTransmissionRequest;
 import com.linkmoa.source.domain.dispatch.error.DispatchErrorCode;
 import com.linkmoa.source.domain.dispatch.exception.DispatchException;
@@ -32,7 +32,7 @@ public class DirectoryTransmissionRequestProcessor implements DispatchProcessor 
 
 	@Override
 	@Transactional
-	public DispatchDetailResponse processRequest(
+	public DispatchSimpleResponse processRequest(
 		DispatchProcessingRequest dispatchProcessingRequest, PrincipalDetails principalDetails) {
 		Long requestId = dispatchProcessingRequest.requestId();
 		RequestStatus requestStatus = dispatchProcessingRequest.requestStatus();
@@ -55,12 +55,12 @@ public class DirectoryTransmissionRequestProcessor implements DispatchProcessor 
 
 		String successMessage;
 
-		return DispatchDetailResponse.builder()
-			.id(directoryTransmissionRequest.getId())
-			.requestStatus(directoryTransmissionRequest.getRequestStatus())
-			.senderEmail(directoryTransmissionRequest.getSender().getEmail())
-			.notificationType(NotificationType.TRANSMIT_DIRECTORY)
-			.build();
+		return DispatchSimpleResponse.of(
+			directoryTransmissionRequest.getId(),
+			directoryTransmissionRequest.getRequestStatus(),
+			directoryTransmissionRequest.getSender().getEmail(),
+			NotificationType.TRANSMIT_DIRECTORY
+		);
 
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/dispatch/service/processor/DispatchProcessor.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/service/processor/DispatchProcessor.java
@@ -3,13 +3,13 @@ package com.linkmoa.source.domain.dispatch.service.processor;
 import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
 import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
 import com.linkmoa.source.domain.dispatch.dto.request.DispatchProcessingRequest;
-import com.linkmoa.source.domain.dispatch.dto.response.DispatchDetailResponse;
+import com.linkmoa.source.domain.dispatch.dto.response.DispatchSimpleResponse;
 import com.linkmoa.source.domain.dispatch.error.DispatchErrorCode;
 import com.linkmoa.source.domain.dispatch.exception.DispatchException;
 import com.linkmoa.source.domain.notification.constant.NotificationType;
 
 public interface DispatchProcessor {
-	DispatchDetailResponse processRequest(DispatchProcessingRequest dispatchProcessingRequest,
+	DispatchSimpleResponse processRequest(DispatchProcessingRequest dispatchProcessingRequest,
 		PrincipalDetails principalDetails);
 
 	default void validateRequestStatus(RequestStatus status) {

--- a/src/main/java/com/linkmoa/source/domain/dispatch/service/processor/SharePageInvitationRequestProcessor.java
+++ b/src/main/java/com/linkmoa/source/domain/dispatch/service/processor/SharePageInvitationRequestProcessor.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
 import com.linkmoa.source.domain.dispatch.constant.RequestStatus;
 import com.linkmoa.source.domain.dispatch.dto.request.DispatchProcessingRequest;
-import com.linkmoa.source.domain.dispatch.dto.response.DispatchDetailResponse;
+import com.linkmoa.source.domain.dispatch.dto.response.DispatchSimpleResponse;
 import com.linkmoa.source.domain.dispatch.entity.SharePageInvitationRequest;
 import com.linkmoa.source.domain.dispatch.error.DispatchErrorCode;
 import com.linkmoa.source.domain.dispatch.exception.DispatchException;
@@ -33,7 +33,7 @@ public class SharePageInvitationRequestProcessor implements DispatchProcessor {
 
 	@Override
 	@Transactional
-	public DispatchDetailResponse processRequest(
+	public DispatchSimpleResponse processRequest(
 		DispatchProcessingRequest request, PrincipalDetails principalDetails) {
 
 		Long requestId = request.requestId();
@@ -62,12 +62,12 @@ public class SharePageInvitationRequestProcessor implements DispatchProcessor {
 			acceptSharePageInvitation(page, member, permissionType);
 		}
 
-		return DispatchDetailResponse.builder()
-			.id(sharePageInvitationRequest.getId())
-			.requestStatus(sharePageInvitationRequest.getRequestStatus())
-			.senderEmail(sharePageInvitationRequest.getSender().getEmail())
-			.notificationType(NotificationType.INVITE_PAGE)
-			.build();
+		return DispatchSimpleResponse.of(
+			sharePageInvitationRequest.getId(),
+			sharePageInvitationRequest.getRequestStatus(),
+			sharePageInvitationRequest.getSender().getEmail(),
+			NotificationType.INVITE_PAGE
+		);
 
 	}
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[0] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치
feature/LP-188 -> develop 

### 변경 사항
알람 수신 목록 조회 데이터를 추가했습니다. 

1.알람 목록 응답 구조 수정
 - DirectoryTransmissionRequests, SharePageInvitationRequests로 구분
 - senderInfo, message 필드 추가
   -senderInfo 구조 
     -email
     -nickname
     -colorCode
     -sendAt

2.각 요청에 대한 메시지 포맷 추가 (닉네임(이메일)님이 ~했습니다.)

### 테스트 결과
포스트맨으로 테스트를 진행했으며, 테스트 코드 추후 작성 예정입니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 디렉터리 전송 요청 및 공유 페이지 초대 요청에 대한 간소화된 응답 형태가 추가되었습니다.
    - 상세한 발신자 정보를 포함하는 새로운 데이터 구조가 도입되었습니다.

- **버그 수정**
    - 없음

- **리팩터링**
    - 일부 응답 데이터가 간단한 형태로 변경되어 처리 속도 및 효율성이 개선되었습니다.
    - 내부 데이터 전달 구조가 개선되어, 발신자 정보와 메시지 표현이 더욱 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->