### PR TITLE
Feature/LP-190 refactor: GET 메서드의 RequestBody 제거 및 Query Parameter 기반 요청 방식으로 변경

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/directory/controller/DirectoryApiController.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/controller/DirectoryApiController.java
@@ -100,7 +100,7 @@ public class DirectoryApiController {
 	public ResponseEntity<ApiResponseSpec<DirectoryIdDto.Response>> getDirectory(
 		@RequestParam("pageId") Long pageId,
 		@RequestParam("commandType") CommandType commandType,
-		@RequestParam("directroyId") Long directoryId,
+		@RequestParam("directoryId") Long directoryId,
 		@RequestParam("sortType") SortType sortType,
 		@AuthenticationPrincipal PrincipalDetails principalDetails) {
 		return ResponseEntity.ok().body(ApiResponseSpec.success(

--- a/src/main/java/com/linkmoa/source/domain/directory/controller/DirectoryApiController.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/controller/DirectoryApiController.java
@@ -11,16 +11,20 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
+import com.linkmoa.source.domain.directory.constant.SortType;
 import com.linkmoa.source.domain.directory.dto.request.DirectoryChangeParentDto;
 import com.linkmoa.source.domain.directory.dto.request.DirectoryCreateDto;
 import com.linkmoa.source.domain.directory.dto.request.DirectoryDragAndDropDto;
 import com.linkmoa.source.domain.directory.dto.request.DirectoryIdDto;
 import com.linkmoa.source.domain.directory.dto.request.DirectoryPasteDto;
 import com.linkmoa.source.domain.directory.dto.request.DirectoryUpdateDto;
+import com.linkmoa.source.domain.directory.resolver.DirectoryParameterResolver;
 import com.linkmoa.source.domain.directory.service.DirectoryService;
+import com.linkmoa.source.global.constant.CommandType;
 import com.linkmoa.source.global.spec.ApiResponseSpec;
 
 import lombok.RequiredArgsConstructor;
@@ -33,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 public class DirectoryApiController {
 
 	private final DirectoryService directoryService;
+	private final DirectoryParameterResolver directoryParameterResolver;
 
 	@PostMapping
 	@PreAuthorize("isAuthenticated()")
@@ -93,13 +98,17 @@ public class DirectoryApiController {
 	@GetMapping("/details")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponseSpec<DirectoryIdDto.Response>> getDirectory(
-		@RequestBody @Validated DirectoryIdDto.Request directoryIdRequest,
+		@RequestParam("pageId") Long pageId,
+		@RequestParam("commandType") CommandType commandType,
+		@RequestParam("directroyId") Long directoryId,
+		@RequestParam("sortType") SortType sortType,
 		@AuthenticationPrincipal PrincipalDetails principalDetails) {
 		return ResponseEntity.ok().body(ApiResponseSpec.success(
 			HttpStatus.OK,
 			"Directory 클릭 시, 해당 디렉토리 내에 사이트 및 디렉토리를 조회했습니다.",
 			directoryService.findDirectoryDetails(
-				directoryIdRequest, principalDetails)
+				directoryParameterResolver.createDirectoryDetailsRequest(pageId, commandType, directoryId, sortType),
+				principalDetails)
 		));
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/directory/resolver/DirectoryParameterResolver.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/resolver/DirectoryParameterResolver.java
@@ -1,0 +1,22 @@
+package com.linkmoa.source.domain.directory.resolver;
+
+import org.springframework.stereotype.Component;
+
+import com.linkmoa.source.domain.directory.constant.SortType;
+import com.linkmoa.source.domain.directory.dto.request.DirectoryIdDto;
+import com.linkmoa.source.global.constant.CommandType;
+import com.linkmoa.source.global.dto.request.BaseRequest;
+
+@Component
+public class DirectoryParameterResolver {
+
+	public BaseRequest createBaseRequestFrom(Long pageId, CommandType commandType) {
+		return new BaseRequest(pageId, commandType);
+	}
+
+	public DirectoryIdDto.Request createDirectoryDetailsRequest(Long pageId, CommandType commandType, Long directroyId,
+		SortType sortType) {
+		return new DirectoryIdDto.Request(createBaseRequestFrom(pageId, commandType), directroyId, sortType);
+	}
+
+}

--- a/src/main/java/com/linkmoa/source/domain/page/controller/PageApiController.java
+++ b/src/main/java/com/linkmoa/source/domain/page/controller/PageApiController.java
@@ -124,13 +124,14 @@ public class PageApiController {
 	@GetMapping("/dashboard")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponseSpec<SharePageDashboardDto.Response>> getPageDashboard(
-		@RequestBody SharePageDashboardDto.Request request,
+		@RequestParam("pageId") Long pageId,
+		@RequestParam("commandType") CommandType commandType,
 		@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {
 		return ResponseEntity.ok().body(ApiResponseSpec.success(
 			HttpStatus.OK,
 			"공유 페이지 대시보드 정보를 조회합니다.",
-			pageService.getPageDashboard(request)
+			pageService.getPageDashboard(pageParameterResolver.createDashboardRequest(pageId, commandType))
 
 		));
 	}

--- a/src/main/java/com/linkmoa/source/domain/page/controller/PageApiController.java
+++ b/src/main/java/com/linkmoa/source/domain/page/controller/PageApiController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
@@ -24,7 +25,9 @@ import com.linkmoa.source.domain.page.dto.response.PageDetailsResponse;
 import com.linkmoa.source.domain.page.dto.response.PageResponse;
 import com.linkmoa.source.domain.page.dto.response.SharePageLeaveResponse;
 import com.linkmoa.source.domain.page.entity.Page;
+import com.linkmoa.source.domain.page.resolver.PageParameterResolver;
 import com.linkmoa.source.domain.page.service.PageService;
+import com.linkmoa.source.global.constant.CommandType;
 import com.linkmoa.source.global.dto.request.BaseRequest;
 import com.linkmoa.source.global.spec.ApiResponseSpec;
 
@@ -36,6 +39,7 @@ import lombok.RequiredArgsConstructor;
 public class PageApiController {
 
 	private final PageService pageService;
+	private final PageParameterResolver pageParameterResolver;
 
 	@PostMapping
 	@PreAuthorize("isAuthenticated()")
@@ -95,13 +99,14 @@ public class PageApiController {
 	@GetMapping("/details")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<ApiResponseSpec<PageDetailsResponse>> getPageDetails(
-		@RequestBody @Validated BaseRequest baseRequest,
+		@RequestParam("pageId") Long pageId,
+		@RequestParam("commandType") CommandType commandType,
 		@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
 		return ResponseEntity.ok().body(ApiResponseSpec.success(
 			HttpStatus.OK,
 			"페이지 접속 시, 해당 페이지 메인화면을 조회합니다",
-			pageService.getPageMain(baseRequest, principalDetails)
+			pageService.getPageMain(pageParameterResolver.createBaseRequestFrom(pageId, commandType), principalDetails)
 		));
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/page/resolver/PageParameterResolver.java
+++ b/src/main/java/com/linkmoa/source/domain/page/resolver/PageParameterResolver.java
@@ -1,0 +1,21 @@
+package com.linkmoa.source.domain.page.resolver;
+
+import org.springframework.stereotype.Component;
+
+import com.linkmoa.source.global.constant.CommandType;
+import com.linkmoa.source.global.dto.request.BaseRequest;
+
+@Component
+public class PageParameterResolver {
+
+	/*
+	createFrom(...)	명시적이며 팩토리 느낌
+ 	resolveFrom(...)	"입력으로부터 객체를 만들어낸다"는 의미 + 리졸버 컨텍스트에 잘 어울림
+	buildFrom(...)	Builder 느낌, 복잡한 조합일 때
+	convert(...)	변환 느낌, DTO → Entity처럼 매핑할 때 자주 사용
+	 */
+	public BaseRequest createBaseRequestFrom(Long pageId, CommandType commandType) {
+		return new BaseRequest(pageId, commandType);
+	}
+
+}

--- a/src/main/java/com/linkmoa/source/domain/page/resolver/PageParameterResolver.java
+++ b/src/main/java/com/linkmoa/source/domain/page/resolver/PageParameterResolver.java
@@ -2,6 +2,7 @@ package com.linkmoa.source.domain.page.resolver;
 
 import org.springframework.stereotype.Component;
 
+import com.linkmoa.source.domain.page.dto.request.SharePageDashboardDto;
 import com.linkmoa.source.global.constant.CommandType;
 import com.linkmoa.source.global.dto.request.BaseRequest;
 
@@ -16,6 +17,10 @@ public class PageParameterResolver {
 	 */
 	public BaseRequest createBaseRequestFrom(Long pageId, CommandType commandType) {
 		return new BaseRequest(pageId, commandType);
+	}
+
+	public SharePageDashboardDto.Request createDashboardRequest(Long pageId, CommandType commandType) {
+		return new SharePageDashboardDto.Request(createBaseRequestFrom(pageId, commandType));
 	}
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[0] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치

feature/LP-190 -> develop 

### 변경 사항
기존의 GET 메서드의 RequestBody를 제거하고 Query Parameter 기반 요청 방식으로 변경했습니다. 

### 테스트 결과
포스트맨으로 테스트를 진행했으며, 추후 테스트 코드 추가 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 디렉토리 및 페이지 관련 요청 시 쿼리 파라미터 입력 방식을 지원합니다. (pageId, commandType 등)
- **개선 사항**
    - 디렉토리 및 페이지 상세 조회, 대시보드 조회 시 요청 방식이 JSON Body에서 쿼리 파라미터 방식으로 변경되었습니다.
    - 요청 파라미터 조립이 내부적으로 일관성 있게 처리되어, 입력이 보다 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->