### PR TITLE
LP-190 refactor: getMembersByEmailOrNickname 메서드 쿼리 파라미터로 수정

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/search/controller/SearchApiController.java
+++ b/src/main/java/com/linkmoa/source/domain/search/controller/SearchApiController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
@@ -48,13 +49,13 @@ public class SearchApiController {
 	@GetMapping("/members")
 	@PreAuthorize("isAuthenticated()")
 	ResponseEntity<ApiResponseSpec<MemberSearchRequestDto.Response>> getMembersByEmailOrNickname(
-		@RequestBody MemberSearchRequestDto.Request request,
+		@RequestParam("keyword") String keyword,
 		@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {
 		return ResponseEntity.ok().body(ApiResponseSpec.success(
 			HttpStatus.OK,
 			"멤버 조회에 성공했습니다.",
-			searchService.searchMembersByEmailOrNickname(request)
+			searchService.searchMembersByEmailOrNickname(keyword)
 		));
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/search/service/SearchService.java
+++ b/src/main/java/com/linkmoa/source/domain/search/service/SearchService.java
@@ -103,8 +103,8 @@ public class SearchService {
 	}
 
 	public MemberSearchRequestDto.Response searchMembersByEmailOrNickname(
-		MemberSearchRequestDto.Request request) {
-		List<MemberSimpleResponse> memberSimpleResponses = memberDataAccess.searchByKeyword(request.keyword());
+		String keyword) {
+		List<MemberSimpleResponse> memberSimpleResponses = memberDataAccess.searchByKeyword(keyword);
 
 		return new MemberSearchRequestDto.Response(memberSimpleResponses);
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[0] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치
feature/LP-190 -> develop

### 변경 사항
getMembersByEmailOrNickname 메서드 쿼리 파라미터로 수정했습니다.

### 테스트 결과
포스트맨으로 테스트를 진행했으며, 추후 테스트 코드 추가 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 이메일 또는 닉네임으로 회원 검색 시, 검색어 입력 방식을 요청 본문에서 URL 쿼리 파라미터로 변경하여 검색 기능이 더 간편해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->