### PR TITLE
Feature/LP-194 feat : 대시보드 데이터에 페이지 등급 및 컬러 코드 필드 추가

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/page/dto/request/SharePageDashboardDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/request/SharePageDashboardDto.java
@@ -2,6 +2,7 @@ package com.linkmoa.source.domain.page.dto.request;
 
 import java.util.List;
 
+import com.linkmoa.source.domain.page.contant.PageType;
 import com.linkmoa.source.domain.page.contant.PageVisibility;
 import com.linkmoa.source.domain.page.dto.response.PageDashboardMemberDto;
 import com.linkmoa.source.global.dto.request.BaseRequest;
@@ -19,6 +20,8 @@ public class SharePageDashboardDto {
 	public record Response(
 		Long pageId,
 		PageVisibility visibility,
+
+		PageType pageType,
 		List<PageDashboardMemberDto> pageMembers
 	) {
 

--- a/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
@@ -1,15 +1,12 @@
 package com.linkmoa.source.domain.page.dto.response;
 
-import lombok.Builder;
-
-@Builder
 public record PageDashboardMemberDto(
 	Long memberId,
 	String email,
 	String nickName,
 	String colorCode,
 	String role,
-	boolean isWaiting
+	Boolean isWaiting
 ) {
 
 }

--- a/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
+++ b/src/main/java/com/linkmoa/source/domain/page/dto/response/PageDashboardMemberDto.java
@@ -7,6 +7,7 @@ public record PageDashboardMemberDto(
 	Long memberId,
 	String email,
 	String nickName,
+	String colorCode,
 	String role,
 	boolean isWaiting
 ) {

--- a/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
@@ -78,6 +78,7 @@ public class PageQueryDslRepositoryImpl {
 				sharePageInvitationRequest.receiver.id,
 				sharePageInvitationRequest.receiver.email,
 				sharePageInvitationRequest.receiver.nickname,
+				sharePageInvitationRequest.receiver.colorCode,
 				Expressions.constant("UNKNOWN"),
 				Expressions.constant(true)
 			))

--- a/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageQueryDslRepositoryImpl.java
@@ -61,6 +61,7 @@ public class PageQueryDslRepositoryImpl {
 				member.id,
 				member.email,
 				member.nickname,
+				member.colorCode,
 				memberPageLink.permissionType.stringValue(),
 				Expressions.constant(false)
 			))

--- a/src/main/java/com/linkmoa/source/domain/page/service/PageService.java
+++ b/src/main/java/com/linkmoa/source/domain/page/service/PageService.java
@@ -290,6 +290,7 @@ public class PageService {
 
 		return SharePageDashboardDto.Response.builder()
 			.pageId(request.baseRequest().pageId())
+			.pageType(pageDataAccess.findById(request.baseRequest().pageId()).get().getPageType())
 			.visibility(pageDataAccess.findPageVisibilityByPageId(request.baseRequest().pageId()))
 			.pageMembers(allMembers)
 			.build();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[0] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치
feature/LP-194 -> develop

### 변경 사항
대시보드 데이터에 페이지 등급 및 컬러 코드 필드 추가했습니다.

### 테스트 결과
포스트맨으로 진행했으며, 추가 테스트 코드 추가 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 대시보드 응답에 페이지 유형(pageType) 정보가 추가되었습니다.
    - 대시보드 멤버 정보에 색상 코드(colorCode) 필드가 추가되었습니다.

- **개선 사항**
    - 대시보드 멤버의 대기 여부(isWaiting) 필드 타입이 Boolean으로 변경되었습니다.

- **기타**
    - 대시보드 멤버 DTO에서 @Builder 어노테이션이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->