### PR TITLE
Feature/LP-196 feat: 사이트 조회 시 favicon URL 포함하도록 수정

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/site/dto/request/SiteCreateDto.java
+++ b/src/main/java/com/linkmoa/source/domain/site/dto/request/SiteCreateDto.java
@@ -11,7 +11,8 @@ public class SiteCreateDto {
 		BaseRequest baseRequest,
 		@NotBlank @Size(max = 30) String siteName,
 		@NotBlank String siteUrl,
-		Long directoryId
+		Long directoryId,
+		String faviconUrl
 	) {
 
 	}

--- a/src/main/java/com/linkmoa/source/domain/site/dto/response/SiteSimpleResponse.java
+++ b/src/main/java/com/linkmoa/source/domain/site/dto/response/SiteSimpleResponse.java
@@ -12,5 +12,6 @@ public class SiteSimpleResponse {
 	private String siteName;
 	private String siteUrl;
 	private Boolean isFavorite;
+	private String faviconUrl;
 
 }

--- a/src/main/java/com/linkmoa/source/domain/site/entity/Site.java
+++ b/src/main/java/com/linkmoa/source/domain/site/entity/Site.java
@@ -43,11 +43,15 @@ public class Site extends BaseEntity {
 	@Column(name = "order_index")
 	private Integer orderIndex;
 
+	@Column(name = "favicon url")
+	private String faviconUrl;
+
 	@Builder
-	public Site(String siteName, String siteUrl, Directory directory, Integer orderIndex) {
+	public Site(String siteName, String siteUrl, Directory directory, Integer orderIndex, String faviconUrl) {
 		this.siteName = siteName;
 		this.siteUrl = siteUrl;
 		this.orderIndex = orderIndex;
+		this.faviconUrl = faviconUrl;
 		setDirectory(directory);
 
 	}

--- a/src/main/java/com/linkmoa/source/domain/site/entity/Site.java
+++ b/src/main/java/com/linkmoa/source/domain/site/entity/Site.java
@@ -43,7 +43,7 @@ public class Site extends BaseEntity {
 	@Column(name = "order_index")
 	private Integer orderIndex;
 
-	@Column(name = "favicon url")
+	@Column(name = "favicon_url")
 	private String faviconUrl;
 
 	@Builder

--- a/src/main/java/com/linkmoa/source/domain/site/error/SiteErrorCode.java
+++ b/src/main/java/com/linkmoa/source/domain/site/error/SiteErrorCode.java
@@ -10,7 +10,8 @@ import lombok.Getter;
 public enum SiteErrorCode implements ErrorCode {
 
 	SITE_NOT_FOUND(HttpStatus.NOT_FOUND, "Site를 찾을 수 없습니다."),
-	SITE_ERRORCODE_TEST(HttpStatus.NOT_FOUND, "site error code 테스트");
+	SITE_ERRORCODE_TEST(HttpStatus.NOT_FOUND, "site error code 테스트"),
+	INVALID_URL(HttpStatus.BAD_REQUEST, "잘못된 URL 형식입니다.");
 
 	private HttpStatus httpStatus;
 	private String errorMessage;

--- a/src/main/java/com/linkmoa/source/domain/site/error/SiteErrorCode.java
+++ b/src/main/java/com/linkmoa/source/domain/site/error/SiteErrorCode.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 public enum SiteErrorCode implements ErrorCode {
 
 	SITE_NOT_FOUND(HttpStatus.NOT_FOUND, "Site를 찾을 수 없습니다."),
-	SITE_ERRORCODE_TEST(HttpStatus.NOT_FOUND, "site error code 테스트"),
 	INVALID_URL(HttpStatus.BAD_REQUEST, "잘못된 URL 형식입니다.");
 
 	private HttpStatus httpStatus;

--- a/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
@@ -45,6 +45,7 @@ public class SiteQueryDslRepositoryImpl {
 				.siteName(s.getSiteName())
 				.orderIndex(sortType == SortType.BASIC ? s.getOrderIndex() : null)
 				.isFavorite(favoriteSiteIds.contains(s.getId()))
+				.faviconUrl(s.getFaviconUrl())
 				.build())
 			.collect(Collectors.toList());
 

--- a/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
@@ -61,7 +61,8 @@ public class SiteQueryDslRepositoryImpl {
 					site.id,
 					site.siteName,
 					site.siteUrl,
-					Expressions.constant(true)
+					Expressions.constant(true),
+					site.faviconUrl
 				)
 			)
 			.from(site)

--- a/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
+++ b/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
@@ -1,8 +1,5 @@
 package com.linkmoa.source.domain.site.service;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +29,8 @@ public class SiteService {
 	private final DirectoryDataAccess directoryDataAccess;
 
 	@ValidationApplied
-	public Long createSite(SiteCreateDto.Request request,
+	public Long createSite(
+		SiteCreateDto.Request request,
 		PrincipalDetails principalDetails) {
 
 		Directory directory = directoryDataAccess.findById(request.directoryId())
@@ -45,21 +43,12 @@ public class SiteService {
 			.siteUrl(request.siteUrl())
 			.directory(directory)
 			.orderIndex(nextOrderIndex)
-			.faviconUrl(extractFaviconUrl(request.siteUrl()))
+			.faviconUrl(request.faviconUrl())
 			.build();
 
 		siteDataAccess.save(newSite);
 		return newSite.getId();
 
-	}
-
-	private static String extractFaviconUrl(String siteUrl) {
-		try {
-			URL url = new URL(siteUrl);
-			return url.getProtocol() + "://" + url.getHost() + "/favicon.ico";
-		} catch (MalformedURLException e) {
-			throw new SiteException(SiteErrorCode.INVALID_URL);
-		}
 	}
 
 	@ValidationApplied

--- a/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
+++ b/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
@@ -1,5 +1,8 @@
 package com.linkmoa.source.domain.site.service;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +50,15 @@ public class SiteService {
 		siteDataAccess.save(newSite);
 		return newSite.getId();
 
+	}
+
+	private String extractFaviconUrl(String siteUrl) throws MalformedURLException {
+		try {
+			URL url = new URL(siteUrl);
+			return url.getProtocol() + "://" + url.getHost() + "/favicon.ico";
+		} catch (MalformedURLException e) {
+			throw new SiteException(SiteErrorCode.INVALID_URL);
+		}
 	}
 
 	@ValidationApplied

--- a/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
+++ b/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
@@ -52,7 +52,7 @@ public class SiteService {
 
 	}
 
-	private static String extractFaviconUrl(String siteUrl) throws MalformedURLException {
+	private static String extractFaviconUrl(String siteUrl) {
 		try {
 			URL url = new URL(siteUrl);
 			return url.getProtocol() + "://" + url.getHost() + "/favicon.ico";

--- a/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
+++ b/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
@@ -52,7 +52,7 @@ public class SiteService {
 
 	}
 
-	private String extractFaviconUrl(String siteUrl) throws MalformedURLException {
+	private static String extractFaviconUrl(String siteUrl) throws MalformedURLException {
 		try {
 			URL url = new URL(siteUrl);
 			return url.getProtocol() + "://" + url.getHost() + "/favicon.ico";

--- a/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
+++ b/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
@@ -45,6 +45,7 @@ public class SiteService {
 			.siteUrl(request.siteUrl())
 			.directory(directory)
 			.orderIndex(nextOrderIndex)
+			.faviconUrl(extractFaviconUrl(request.siteUrl()))
 			.build();
 
 		siteDataAccess.save(newSite);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[0] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치
feature/LP-196 -> develop 

### 변경 사항
사이트 데이터를 조회할 경우 favicon URL을 응답에 포함하도록 수정했습니다.

### 테스트 결과
포스트맨으로 테스트를 진행했으며, 추후 테스트 코드 작성 예정입니다.