### PR TITLE
Feature/LP-170 feat : 페이지 내 디렉토리 및 사이트 제목 기반  검색 기능 구현

### DIFF
--- a/src/main/java/com/linkmoa/source/domain/directory/entity/Directory.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/entity/Directory.java
@@ -65,11 +65,15 @@ public class Directory extends BaseEntity {
 	@Column(name = "order_index")
 	private Integer orderIndex;
 
+	@Column(name = "page_id")
+	private Long pageId;
+
 	@Builder
-	public Directory(String directoryName, String directoryDescription, Integer orderIndex) {
+	public Directory(String directoryName, String directoryDescription, Integer orderIndex, Long pageId) {
 		this.directoryName = directoryName;
 		this.directoryDescription = directoryDescription;
 		this.orderIndex = orderIndex;
+		this.pageId = pageId;
 	}
 
 	public void setParentDirectory(Directory parentDirectory) {

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/DirectoryDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/DirectoryDataAccess.java
@@ -9,7 +9,6 @@ import com.linkmoa.source.domain.directory.dto.response.DirectorySimpleResponse;
 import com.linkmoa.source.domain.directory.entity.Directory;
 
 public interface DirectoryDataAccess {
-	// ⭐ 추가해야 하는 기본 CRUD 메서드
 	Directory save(Directory directory);
 
 	Optional<Directory> findById(Long id);

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/DirectoryDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/DirectoryDataAccess.java
@@ -44,4 +44,7 @@ public interface DirectoryDataAccess {
 
 	String findFullPathByDirectoryId(Long directoryId);
 
+	List<DirectorySimpleResponse> findDirectoriesByKeywordAndPageId(final String keyword, final Long pageId,
+		final Long memberId);
+
 }

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/adapter/DirectoryDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/adapter/DirectoryDataAccessImpl.java
@@ -104,4 +104,12 @@ public class DirectoryDataAccessImpl implements DirectoryDataAccess {
 		return directoryJpaRepository.findFullPathByDirectoryId(directoryId);
 	}
 
+	@Override
+	public List<DirectorySimpleResponse> findDirectoriesByKeywordAndPageId(
+		final String keyword,
+		final Long pageId,
+		final Long memberId) {
+		return null;
+	}
+
 }

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/adapter/DirectoryDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/adapter/DirectoryDataAccessImpl.java
@@ -109,7 +109,7 @@ public class DirectoryDataAccessImpl implements DirectoryDataAccess {
 		final String keyword,
 		final Long pageId,
 		final Long memberId) {
-		return null;
+		return directoryQueryDslRepository.findDirectoriesByKeywordAndPageId(keyword, pageId, memberId);
 	}
 
 }

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/rdb/DirectoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/rdb/DirectoryQueryDslRepositoryImpl.java
@@ -141,4 +141,30 @@ public class DirectoryQueryDslRepositoryImpl {
 			.fetch();
 	}
 
+	public List<DirectorySimpleResponse> findDirectoriesByKeywordAndPageId(
+		final String keyword,
+		final Long pageId,
+		final Long memberId) {
+
+		return jpaQueryFactory
+			.select(
+				Projections.constructor(
+					DirectorySimpleResponse.class,
+					directory.id,
+					directory.directoryName,
+					favorite.id.isNotNull()
+				)
+			)
+			.from(directory)
+			.leftJoin(favorite)
+			.on(favorite.itemId.eq(directory.id)
+				.and(favorite.itemType.eq(ItemType.DIRECTORY))
+				.and(favorite.member.id.eq(memberId)))
+			.where(
+				directory.pageId.eq(pageId),
+				directory.directoryName.containsIgnoreCase(keyword)
+			)
+			.fetch();
+	}
+
 }

--- a/src/main/java/com/linkmoa/source/domain/directory/repository/rdb/DirectoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/repository/rdb/DirectoryQueryDslRepositoryImpl.java
@@ -164,6 +164,7 @@ public class DirectoryQueryDslRepositoryImpl {
 				directory.pageId.eq(pageId),
 				directory.directoryName.containsIgnoreCase(keyword)
 			)
+			.orderBy(directory.directoryName.asc())
 			.fetch();
 	}
 

--- a/src/main/java/com/linkmoa/source/domain/directory/service/DirectoryService.java
+++ b/src/main/java/com/linkmoa/source/domain/directory/service/DirectoryService.java
@@ -63,6 +63,7 @@ public class DirectoryService {
 			.directoryName(request.directoryName())
 			.directoryDescription(request.directoryDescription())
 			.orderIndex(nextOrderIndex)
+			.pageId(request.baseRequest().pageId())
 			.build();
 
 		// 부모 디렉토리에 새 디렉토리 추가

--- a/src/main/java/com/linkmoa/source/domain/page/repository/PageDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/PageDataAccess.java
@@ -18,8 +18,6 @@ public interface PageDataAccess {
 
 	void delete(Page page);
 
-	List<Object[]> findDirectoriesAndSitesByNameKeyword(String name, Long rootDirectoryId, Long memberId);
-
 	List<PageResponse> findAllPagesByMemberId(Long memberId);
 
 	Long findRootDirectoryIdByPageId(Long pageId);

--- a/src/main/java/com/linkmoa/source/domain/page/repository/adapter/PageDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/adapter/PageDataAccessImpl.java
@@ -43,11 +43,6 @@ public class PageDataAccessImpl implements PageDataAccess {
 	}
 
 	@Override
-	public List<Object[]> findDirectoriesAndSitesByNameKeyword(String name, Long rootDirectoryId, Long memberId) {
-		return pageJpaRepository.findDirectoriesAndSitesByNameKeyword(name, rootDirectoryId, memberId);
-	}
-
-	@Override
 	public List<PageResponse> findAllPagesByMemberId(Long memberId) {
 		return pageQueryDslRepository.findAllPagesByMemberId(memberId);
 	}

--- a/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageJpaRepository.java
+++ b/src/main/java/com/linkmoa/source/domain/page/repository/rdb/PageJpaRepository.java
@@ -1,7 +1,5 @@
 package com.linkmoa.source.domain.page.repository.rdb;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,37 +7,6 @@ import org.springframework.data.repository.query.Param;
 import com.linkmoa.source.domain.page.entity.Page;
 
 public interface PageJpaRepository extends JpaRepository<Page, Long> {
-
-	// TODO : 검색 관련 모든 기능 수정해야됨
-	@Query(value =
-		"WITH RECURSIVE DirectoryTree AS ( " +
-			"   SELECT directory_id, parent_directory_id, name " +
-			"   FROM directory " +
-			"   WHERE directory_id = :rootDirectoryId " +
-			"   UNION ALL " +
-			"   SELECT d.directory_id, d.parent_directory_id, d.name " +
-			"   FROM directory d " +
-			"   INNER JOIN DirectoryTree dt ON d.parent_directory_id = dt.directory_id " +
-			") " +
-			"SELECT " +
-			"    d.directory_id AS directory_id, " +
-			"    d.name AS directory_name, " +
-			"    CASE WHEN f1.favorite_id IS NOT NULL THEN true ELSE false END AS is_directory_favorite, " +
-			"    s.site_id AS site_id, " +
-			"    s.name AS site_name, " +
-			"    s.url AS site_url, " +
-			"    CASE WHEN f2.favorite_id IS NOT NULL THEN true ELSE false END AS is_site_favorite " +
-			"FROM DirectoryTree d " +
-			"LEFT JOIN site s ON s.directory_id = d.directory_id " +
-			"LEFT JOIN favorite f1 ON f1.item_id = d.directory_id AND f1.member_id = :memberId AND f1.item_type = 'DIRECTORY' "
-			+
-			"LEFT JOIN favorite f2 ON f2.item_id = s.site_id AND f2.member_id = :memberId AND f2.item_type = 'SITE' " +
-			"WHERE d.name LIKE CONCAT('%', :name, '%') OR s.name LIKE CONCAT('%', :name, '%') " +
-			"ORDER BY d.name ASC, s.name ASC", nativeQuery = true)
-	List<Object[]> findDirectoriesAndSitesByNameKeyword(
-		@Param("name") String name,
-		@Param("rootDirectoryId") Long rootDirectoryId,
-		@Param("memberId") Long memberId);
 
 	@Query("SELECT p.pageTitle FROM Page p WHERE p.id = :pageId")
 	String findPageTitleById(@Param("pageId") Long pageId);

--- a/src/main/java/com/linkmoa/source/domain/search/service/SearchService.java
+++ b/src/main/java/com/linkmoa/source/domain/search/service/SearchService.java
@@ -1,6 +1,5 @@
 package com.linkmoa.source.domain.search.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -8,13 +7,14 @@ import org.springframework.stereotype.Service;
 
 import com.linkmoa.source.auth.oauth2.principal.PrincipalDetails;
 import com.linkmoa.source.domain.directory.dto.response.DirectorySimpleResponse;
+import com.linkmoa.source.domain.directory.repository.DirectoryDataAccess;
 import com.linkmoa.source.domain.member.dto.response.MemberSimpleResponse;
 import com.linkmoa.source.domain.member.repository.MemberDataAccess;
-import com.linkmoa.source.domain.page.repository.PageDataAccess;
 import com.linkmoa.source.domain.search.dto.request.MemberSearchRequestDto;
 import com.linkmoa.source.domain.search.dto.request.SearchRequest;
 import com.linkmoa.source.domain.search.dto.response.SearchPageResponse;
 import com.linkmoa.source.domain.site.dto.response.SiteSimpleResponse;
+import com.linkmoa.source.domain.site.repository.SiteDataAccess;
 import com.linkmoa.source.global.spec.ApiResponseSpec;
 
 import lombok.RequiredArgsConstructor;
@@ -25,28 +25,23 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SearchService {
 
-	private final PageDataAccess pageDataAccess;
 	private final MemberDataAccess memberDataAccess;
+	private final DirectoryDataAccess directoryDataAccess;
+	private final SiteDataAccess siteDataAccess;
 
-	public ApiResponseSpec<SearchPageResponse> searchDirectoriesAndSitesByTitleInPage(SearchRequest searchRequest,
-		PrincipalDetails principalDetails) {
-		Long rootDirectoryIdByPageId = pageDataAccess.findRootDirectoryIdByPageId(searchRequest.pageId());
+	public ApiResponseSpec<SearchPageResponse> searchDirectoriesAndSitesByTitleInPage(
+		final SearchRequest request,
+		final PrincipalDetails principalDetails) {
 
-		log.debug("🔍 pageSerivce Search 요청: pageId={}, keyword='{}', type={}",
-			searchRequest.pageId(),
-			searchRequest.keyword(),
-			searchRequest.searchType());
+		List<DirectorySimpleResponse> directories = directoryDataAccess.findDirectoriesByKeywordAndPageId(
+			request.keyword(),
+			request.pageId(),
+			principalDetails.getMember().getId());
 
-		List<Object[]> directoriesAndSitesByKeyword = pageDataAccess.findDirectoriesAndSitesByNameKeyword(
-			searchRequest.keyword(),
-			rootDirectoryIdByPageId,
-			principalDetails.getId());
-		log.debug("🔍 pageDataAccess Search 요청: ");
-
-		List<DirectorySimpleResponse> directories = mapToDirectoryResponses(
-			directoriesAndSitesByKeyword);
-
-		List<SiteSimpleResponse> sites = mapToSiteResponses(directoriesAndSitesByKeyword);
+		List<SiteSimpleResponse> sites = siteDataAccess.findSitesByKeywordAndPageId(
+			request.keyword(),
+			request.pageId(),
+			principalDetails.getMember().getId());
 
 		SearchPageResponse searchPageResponse = SearchPageResponse.builder()
 			.directorySimpleResponses(directories)
@@ -58,48 +53,6 @@ public class SearchService {
 			"사이트 내에 있는 모든 디렉토리와 사이트를 제목으로 검색합니다.",
 			searchPageResponse
 		);
-	}
-
-	private List<DirectorySimpleResponse> mapToDirectoryResponses(List<Object[]> rawResults) {
-		List<DirectorySimpleResponse> directories = new ArrayList<>();
-
-		for (Object[] row : rawResults) {
-			Long directoryId = (Long)row[0];
-			String directoryName = (String)row[1];
-			Boolean isDirectoryFavorite = (Boolean)row[2];
-
-			directories.add(
-				DirectorySimpleResponse.builder()
-					.directoryId(directoryId)
-					.directoryName(directoryName)
-					.isFavorite(isDirectoryFavorite)
-					.build()
-			);
-		}
-
-		return directories;
-	}
-
-	private List<SiteSimpleResponse> mapToSiteResponses(List<Object[]> rawResults) {
-		List<SiteSimpleResponse> sites = new ArrayList<>();
-
-		for (Object[] row : rawResults) {
-			Long siteId = (Long)row[3];
-			String siteName = (String)row[4];
-			String siteUrl = (String)row[5];
-			Boolean isSiteFavorite = (Boolean)row[6];
-
-			sites.add(
-				SiteSimpleResponse.builder()
-					.siteId(siteId)
-					.siteName(siteName)
-					.siteUrl(siteUrl)
-					.isFavorite(isSiteFavorite)
-					.build()
-			);
-
-		}
-		return sites;
 	}
 
 	public MemberSearchRequestDto.Response searchMembersByEmailOrNickname(

--- a/src/main/java/com/linkmoa/source/domain/site/entity/Site.java
+++ b/src/main/java/com/linkmoa/source/domain/site/entity/Site.java
@@ -46,12 +46,17 @@ public class Site extends BaseEntity {
 	@Column(name = "favicon_url")
 	private String faviconUrl;
 
+	@Column(name = "page_id")
+	private Long pageId;
+
 	@Builder
-	public Site(String siteName, String siteUrl, Directory directory, Integer orderIndex, String faviconUrl) {
+	public Site(String siteName, String siteUrl, Directory directory, Integer orderIndex, String faviconUrl,
+		Long pageId) {
 		this.siteName = siteName;
 		this.siteUrl = siteUrl;
 		this.orderIndex = orderIndex;
 		this.faviconUrl = faviconUrl;
+		this.pageId = pageId;
 		setDirectory(directory);
 
 	}

--- a/src/main/java/com/linkmoa/source/domain/site/repository/SiteDataAccess.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/SiteDataAccess.java
@@ -18,4 +18,9 @@ public interface SiteDataAccess {
 	List<SiteDetailResponse> findSitesDetails(Long directoryId, List<Long> favoriteSiteIds, SortType sortType);
 
 	List<SiteSimpleResponse> findFavoriteSites(List<Long> favoriteSitesIds);
+
+	List<SiteSimpleResponse> findSitesByKeywordAndPageId(
+		final String keyword,
+		final Long pageId,
+		final Long memberId);
 }

--- a/src/main/java/com/linkmoa/source/domain/site/repository/adapter/SiteDataAccessImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/adapter/SiteDataAccessImpl.java
@@ -46,4 +46,12 @@ public class SiteDataAccessImpl implements SiteDataAccess {
 	public List<SiteSimpleResponse> findFavoriteSites(List<Long> favoriteSitesIds) {
 		return siteQueryDslRepository.findFavoriteSites(favoriteSitesIds);
 	}
+
+	@Override
+	public List<SiteSimpleResponse> findSitesByKeywordAndPageId(
+		final String keyword,
+		final Long pageId,
+		final Long memberId) {
+		return siteQueryDslRepository.findSitesByKeywordAndPageId(keyword, pageId, memberId);
+	}
 }

--- a/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
@@ -73,4 +73,31 @@ public class SiteQueryDslRepositoryImpl {
 			.orderBy(favorite.createdAt.asc())
 			.fetch();
 	}
+
+	public List<SiteSimpleResponse> findSitesByKeywordAndPageId(
+		final String keyword,
+		final Long pageId,
+		final Long memberId) {
+		return jpaQueryFactory
+			.select(
+				Projections.constructor(
+					SiteSimpleResponse.class,
+					site.id,
+					site.siteName,
+					site.siteUrl,
+					favorite.id.isNotNull(),
+					site.faviconUrl
+				)
+			)
+			.from(site)
+			.leftJoin(favorite)
+			.on(favorite.itemId.eq(site.id)
+				.and(favorite.itemType.eq(ItemType.SITE))
+				.and(favorite.member.id.eq(memberId)))
+			.where(
+				site.pageId.eq(pageId),
+				site.siteName.containsIgnoreCase(keyword)
+			)
+			.fetch();
+	}
 }

--- a/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
+++ b/src/main/java/com/linkmoa/source/domain/site/repository/rdb/SiteQueryDslRepositoryImpl.java
@@ -98,6 +98,7 @@ public class SiteQueryDslRepositoryImpl {
 				site.pageId.eq(pageId),
 				site.siteName.containsIgnoreCase(keyword)
 			)
+			.orderBy(site.siteName.asc())
 			.fetch();
 	}
 }

--- a/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
+++ b/src/main/java/com/linkmoa/source/domain/site/service/SiteService.java
@@ -44,6 +44,7 @@ public class SiteService {
 			.directory(directory)
 			.orderIndex(nextOrderIndex)
 			.faviconUrl(request.faviconUrl())
+			.pageId(request.baseRequest().pageId())
 			.build();
 
 		siteDataAccess.save(newSite);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[0] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] 코드 리팩토링 
-[] 문서 수정 

### 반영 브랜치
feature/LP-170 -> develop 

### 변경 사항
페이지 내 디렉토리 및 사이트를 제목 기반으로  검색할 수 있는 기능을 구현했습니다.

1.Directory, Site 엔티티에 검색을 위한  pageId 필드 추가
2.createDirectory, createSite 메서드에 pageId 저장 로직 추가
3.기존 findDirectoriesAndSitesByNameKeyword 쿼리 제거
4.QueryDSL 기반 키워드 검색 기능 구현
 4-1.디렉토리: findDirectoriesByKeywordAndPageId
 4-2.사이트: findSitesByKeywordAndPageId
5.디렉토리 및 사이트 모두 이름 기준 오름차순 정렬 적용


### 테스트 결과
포스트맨으로 테스트를 진행했으며 추후 테스트 코드를 작성할 계획입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 디렉터리 및 사이트에 pageId 필드가 추가되어, 페이지별로 디렉터리와 사이트를 검색할 수 있습니다.
    - 키워드와 페이지 ID로 디렉터리 및 사이트를 검색하는 기능이 추가되었습니다.

- **버그 수정**
    - 디렉터리 및 사이트 생성 시 pageId가 올바르게 저장되도록 개선되었습니다.

- **리팩터링**
    - 검색 서비스가 디렉터리와 사이트를 별도로 조회하도록 구조가 개선되었습니다.
    - 불필요한 통합 검색 관련 메서드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->